### PR TITLE
Use File::Temp::tempfile() instead of POSIX::tmpnam()

### DIFF
--- a/sbin/si_lsimage
+++ b/sbin/si_lsimage
@@ -25,6 +25,7 @@
 # declare modules
 use POSIX;
 use Fcntl ':flock';
+use File::Temp qw(tempfile);
 use Getopt::Long;
 use JSON;
 
@@ -179,9 +180,8 @@ my %images = ();
 
 # get listing
 my $workers = 0;
-my $stdout_lockfile = tmpnam();
-open(LOCK, '>', $stdout_lockfile) or
-	die("ERROR: couldn't open: $stdout_lockfile\n");
+my ($lock_fh, $lock_file) = tempfile() or
+	die("ERROR: couldn't create temporary file\n");
 
 if(!$json) {
     print "--------------------------------------------------------------------------------\n";
@@ -261,7 +261,7 @@ while (<FILE>) {
     } else {
 	    $line = "  $_";
     }
-    flock(LOCK, LOCK_EX);
+    flock($lock_fh, LOCK_EX);
     # create hash new entry
     if($json) {
         my %image_hash = ('image_name' => $image_name, 'image_timestamp' => $image_timestamp, 'image_goldenclient' => $image_goldenclient);
@@ -270,7 +270,7 @@ while (<FILE>) {
     } else {
         print "$line\n";
     }
-    flock(LOCK, LOCK_UN);
+    flock($lock_fh, LOCK_UN);
     exit(0);
 }
 close(FILE);
@@ -280,8 +280,8 @@ while ($workers) {
 	$workers--;
 }
 
-close(LOCK);
-unlink($stdout_lockfile);
+close($lock_fh);
+unlink($lock_file);
 if(!$json) {
     print "\n";
 }

--- a/sbin/si_prepareclient
+++ b/sbin/si_prepareclient
@@ -77,6 +77,7 @@ use POSIX;
 use File::Copy;
 use File::Path;
 use File::Basename;
+use File::Temp qw(tempfile);
 use Getopt::Long;
 use vars qw($VERSION);
 use SystemImager::Common;
@@ -89,10 +90,10 @@ $VERSION = "SYSTEMIMAGER_VERSION_STRING";
 my $backup_extension = ".before_systemimager-$VERSION";
 
 # location of temporary rsyncd.conf file
-my $rsyncd_conf_file = tmpnam();
+my (undef, $rsyncd_conf_file) = tempfile(OPEN => 0);
 
 # location of temporary log file
-my $rsyncd_log_file = tmpnam();
+my (undef, $rsyncd_log_file) = tempfile(OPEN => 0);
 
 # set path
 $ENV{PATH} = "/bin:/usr/bin:/usr/local/bin:/sbin:/usr/sbin:/usr/local/sbin";

--- a/sbin/si_updateclient
+++ b/sbin/si_updateclient
@@ -37,6 +37,7 @@ use strict;
 use Socket;
 use AppConfig;
 use File::Copy;
+use File::Temp qw(tempfile);
 use Getopt::Long;
 use Sys::Hostname;
 use SystemImager::Common;
@@ -460,7 +461,7 @@ SC_EOF
         exit(1);
     }
     unless ($image) {
-        my $tmpfile = tmpnam();
+        my (undef, $tmpfile) = tempfile(OPEN => 0);
         my $cmd = "rsync rsync://${server}:${port}/scripts/cluster.txt $tmpfile";
         unless (!system($cmd)) {
             print STDERR "error: couldn't retrieve rsync://${server}:${port}/scripts/cluster.txt from the image server!\n";


### PR DESCRIPTION
POSIX:tmpnam() was removed in Perl 5.25.1:
http://perl11.org/pod/perl5251delta.html